### PR TITLE
Pull special params from parent object

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+enum34==1.0.4
+mock==1.2.0
+nose==1.3.7
+requests==2.7.0
+vdf==1.9

--- a/steam/webapi.py
+++ b/steam/webapi.py
@@ -213,9 +213,10 @@ class WebAPIMethod(object):
         params = {}
         # process special case kwargs
         for param in ('key', 'format', 'raw'):
-            if param in kwargs:
-                params[param] = kwargs[param]
-                del kwargs[param]
+            if param not in kwargs:
+                parent_param = getattr(self._parent._parent, param, None)
+                if parent_param:
+                    kwargs[param] = parent_param
 
         # process method parameters
         for param in self.parameters.values():

--- a/test/test_webapi.py
+++ b/test/test_webapi.py
@@ -1,0 +1,37 @@
+import mock
+from steam import webapi
+import unittest
+
+
+class TestWebAPI(unittest.TestCase):
+    @mock.patch('steam.webapi.WebAPI._api_request', mock.Mock())
+    @mock.patch('steam.webapi.WebAPI.load_interfaces', mock.Mock())
+    def test_with_key(self):
+        api = webapi.WebAPI(key='testkey')
+        api.ISteamUser = webapi.WebAPIInterface({
+            'name': 'ISteamUser',
+            'methods': [
+                {
+                    "name": "GetPlayerSummaries",
+                    "version": 2,
+                    "httpmethod": "GET",
+                    "parameters": [
+                        {
+                            "name": "key",
+                            "type": "string",
+                            "optional": False,
+                            "description": "access key"
+                        },
+                        {
+                            "name": "steamids",
+                            "type": "string",
+                            "optional": False,
+                            "description": "Comma-delimited list of SteamIDs (max: 100)"
+                        }
+                    ]
+
+                },
+
+            ]
+        }, parent=api)
+        api.ISteamUser.GetPlayerSummaries(steamids='76561197960435530')


### PR DESCRIPTION
Hi! Thanks for putting this together.

I found that using a method that required the key parameter actually didn't work, even if you put the key in the arguments for the method itself. This was because webapi.py#218 deleted it from kwargs, but a line later on tested for its existence in kwargs as it is a required parameter for the method. 

I wondered about letting it pass through to _api_request on the API, as you would add it there, but eventually decided it seemed tidier to catch it here. Not sure what you think, either would work fine.