### PR TITLE
Conditionally install enum34 only if Python < 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ nose
 coverage
 mock
 requests
-enum34
 vcrpy

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,21 @@
 from setuptools import setup
 from codecs import open
 from os import path
-
+import sys
 
 here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 with open(path.join(here, 'steam/__init__.py'), encoding='utf-8') as f:
     __version__ = f.readline().split('"')[1]
+
+install_requires = [
+    'requests',
+    'vdf',
+]
+
+if sys.version_info < (3, 4):
+    install_requires.append('enum34>=1.0.4')
 
 setup(
     name='steam',
@@ -30,10 +38,6 @@ setup(
     ],
     keywords='valve steam steamid api webapi',
     packages=['steam'],
-    install_requires=[
-        'enum34',
-        'requests',
-        'vdf',
-    ],
+    install_requires=install_requires,
     zip_safe=True,
 )


### PR DESCRIPTION
This allows installation on Python 3.5.  'pip install steam' on 3.5 currently is failing (but works on 3.4).