### PR TITLE
Added shortcut function to send_messages and wait for them.

### DIFF
--- a/steam/client/__init__.py
+++ b/steam/client/__init__.py
@@ -205,6 +205,39 @@ class SteamClient(EventEmitter, FeatureBase):
 
         return "job_%d" % jobid
 
+    def wait_for_job(self, message, timeout=None):
+        """
+        Send a message as a job and waits for the response.  
+        .. note::
+            Not all messages are jobs, you'll have to find out which are which
+
+        :param message: a message instance
+        :type message: :class:`steam.core.msg.Msg`, :class:`steam.core.msg.MsgProto`
+        :param timeout: how long to wait for a response (in seconds)
+        :type timeout: :class:`float`
+        :return: ``response``
+        :rtype :class:`steam.core.msg.Msg`, :class:`steam.core.msg.MsgProto`
+        :raises: ``gevent.Timeout``
+        """
+        job_id = self.send_job(message)
+        return self.wait_event(job_id, timeout, raises=True)[0].body
+        
+    def wait_for_message(self, message, response_emsg, timeout=None):
+        """
+        Send a message to CM and waits for a defined answer.
+
+        :param message: a message instance
+        :type message: :class:`steam.core.msg.Msg`, :class:`steam.core.msg.MsgProto`
+        :param response_emsg: the answer to wait for (one of steam.enums.emsg.EMsg)
+        :type response_emsg: :class:`int`
+        :param timeout: how long to wait for a response (in seconds)
+        :type timeout: :class:`float`
+        :param message: a message instance
+        :raises: ``gevent.Timeout``
+        """
+        self.send(message)
+        return self.wait_event(response_emsg, timeout, raises=True)[0].body
+
     def _pre_login(self):
         if self.logged_on:
             logger.debug("Trying to login while logged on???")

--- a/steam/client/__init__.py
+++ b/steam/client/__init__.py
@@ -205,7 +205,7 @@ class SteamClient(EventEmitter, FeatureBase):
 
         return "job_%d" % jobid
 
-    def wait_for_job(self, message, timeout=None):
+    def send_job_and_wait(self, message, timeout=None, raises=False):
         """
         Send a message as a job and waits for the response.  
         .. note::
@@ -220,9 +220,12 @@ class SteamClient(EventEmitter, FeatureBase):
         :raises: ``gevent.Timeout``
         """
         job_id = self.send_job(message)
-        return self.wait_event(job_id, timeout, raises=True)[0].body
+        response = self.wait_event(job_id, timeout, raises=raises)
+        if response is None:
+            return None
+        return response[0].body
         
-    def wait_for_message(self, message, response_emsg, timeout=None):
+    def send_message_and_wait(self, message, response_emsg, timeout=None, raises=False):
         """
         Send a message to CM and waits for a defined answer.
 
@@ -236,7 +239,10 @@ class SteamClient(EventEmitter, FeatureBase):
         :raises: ``gevent.Timeout``
         """
         self.send(message)
-        return self.wait_event(response_emsg, timeout, raises=True)[0].body
+        response = self.wait_event(response_emsg, timeout, raises=raises)
+        if response is None:
+            return None
+        return response[0].body
 
     def _pre_login(self):
         if self.logged_on:


### PR DESCRIPTION
This patch just adds two simple functions to the client to send messages (and jobs) and wait for them.  
This is a really common use case of the client, so it should be as easy as possible to do this.
<hr>
I thought this patch would get a little bit bigger as i though to have seen a response to a message before i had the chance to register for the matching event. But i was NOT able to reproduce this.  
Just in case it will be necessary one day to ensure one does not miss the event, something like this should work:

        result = AsyncResult()
        self.once(response_emsg, result.set)
        self.send(message)
        return result.get(timeout=timeout).body