### PR TITLE
Fixed "TypeError" thrown by SteamUser.__new__()

### DIFF
--- a/steam/client/user.py
+++ b/steam/client/user.py
@@ -14,7 +14,7 @@ class SteamUser(object):
     relationship = EFriendRelationship.No   #: friendship status
 
     def __new__(cls, steam_id, *args, **kwargs):
-        return super(SteamUser, cls).__new__(cls, steam_id)
+        return super(SteamUser, cls).__new__(cls) # removed "steam_id" arg from __new__()
 
     def __init__(self, steam_id, steam):
         self._pstate_ready = Event()

--- a/steam/client/user.py
+++ b/steam/client/user.py
@@ -13,9 +13,6 @@ class SteamUser(object):
     steam_id = SteamID()
     relationship = EFriendRelationship.No   #: friendship status
 
-    def __new__(cls, steam_id, *args, **kwargs):
-        return super(SteamUser, cls).__new__(cls) # removed "steam_id" arg from __new__()
-
     def __init__(self, steam_id, steam):
         self._pstate_ready = Event()
         self._steam = steam


### PR DESCRIPTION
Removed "steam_id" argument from __new__() method call

When a new SteamUser is created, it passes SteamID() as a parameter to its __new__ method via the variable "steam_id", which in turn is passed to super().__new__(), the object class.

The passing of said argument throws the following error:

```
File "C:\Users\User\AppData\Local\Programs\Python\Python35\lib\site-packages\steam\client\user.py", line 17, in __new__
    return super(SteamUser, cls).__new__(cls, steam_id)
TypeError: object() takes no parameters
```

Removing the "steam_id" argument fixes the issue.