### PR TITLE
Fix unhandled exception for invalid numeric SteamIDs

### DIFF
--- a/steam/steamid.py
+++ b/steam/steamid.py
@@ -253,6 +253,9 @@ def make_steam64(id=0, *args, **kwargs):
             # 64 bit
             elif value < 2**64:
                 return value
+            # invalid account id
+            else:
+                accountid = 0
 
         # textual input e.g. [g:1:4]
         else:

--- a/tests/test_steamid.py
+++ b/tests/test_steamid.py
@@ -121,6 +121,12 @@ class SteamID_initialization(unittest.TestCase):
         self.compare(SteamID("invalid_format"),
                      [0, EType.Invalid, EUniverse.Invalid, 0])
 
+    def test_arg_too_large_invalid(self):
+        self.compare(SteamID(111111111111111111111111111111111111111),
+                     [0, EType.Invalid, EUniverse.Invalid, 0])
+        self.compare(SteamID("1111111111111111111111111111111111111"),
+                     [0, EType.Invalid, EUniverse.Invalid, 0])
+
     ######################################################
     # KWARGS
     ######################################################


### PR DESCRIPTION
Hi, Росен!
First of all, thanks for your work on this project! Amazing library.
Upon creation of SteamID object, unhandled TypeError is raised for too large integers or numeric strings instead of creating SteamID object with the invalid flags set.
Example test is provided in the PR.

Cheers and have a nice day! 🍺