### PR TITLE
Remove gevent monkeypatching.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Change notes
 
+## 2.0.0 (in progress)
+
+This release brings breaking changes
+
+### steam.client
+
+- Importing `steam.client` no longer automatically patches `socket or `ssl` to
+  use gevent.
+
 ## 1.0.0
 
 This release brings breaking changes

--- a/steam/client/__init__.py
+++ b/steam/client/__init__.py
@@ -8,11 +8,6 @@ Implementation of Steam client based on ``gevent``
     Optional features are available as :mod:`.mixins`. This allows the client to remain light yet flexible.
 
 """
-import gevent
-import gevent.monkey
-gevent.monkey.patch_socket()
-gevent.monkey.patch_ssl()
-
 import os
 import json
 from random import random


### PR DESCRIPTION
For somebody using this package as a library, it would be preferable to leave
whether to monkeypatch gevent into the standard library up to the user, rather
than forcing it on every consumer.

As far as I can tell, the only place that monkeypatching is used, is for
interacting with requests. The only place this is *directly* used by
the client is in `steam.core.CMClient.boostrap_from_webapi`, which is
only called on the initial connection. Letting that call be synchronous,
if the user doesn't want to use gevent directly seems reasonable.