### PR TITLE
ci: include py3.9 + pypi no cov

### DIFF
--- a/.github/workflows/testing_initiative.yml
+++ b/.github/workflows/testing_initiative.yml
@@ -32,12 +32,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
-#       exclude:
-#         - os: macos-latest
-#           python-version: 3.8
-#         - os: windows-latest
-#           python-version: 3.6
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        no-coverage: [0]
+        include:
+          - os: ubuntu-latest
+            python-version: pypy-2.7
+            no-coverage: 1
+          - os: ubuntu-latest
+            python-version: pypy-3.6
+            no-coverage: 1
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python Env
@@ -50,9 +53,13 @@ jobs:
         run: |
           make init
       - name: Run Tests
+        env:
+            NOCOV: ${{ matrix.no-coverage }}
         run: |
           make test
       - name: Upload to Coveralls
+        # pypy + concurrenct=gevent not supported in coveragepy. See https://github.com/nedbat/coveragepy/issues/560
+        if: matrix.no-coverage == 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
@@ -90,6 +97,8 @@ jobs:
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
-        run: make init
+        run: |
+          make init
+          make init_docs
       - name: Build Docs
         run: make docs

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,21 @@ export HELPBODY
 help:
 	@echo "$$HELPBODY"
 
-init: init_docs
+init:
 	pip install -r dev_requirements.txt
 
 init_docs:
 	pip install sphinx==1.8.5 sphinx_rtd_theme
 
+COVOPTS = --cov-config .coveragerc --cov=steam
+
+ifeq ($(NOCOV), 1)
+	COVOPTS =
+endif
+
 test:
 	coverage erase
-	PYTHONHASHSEED=0 pytest --tb=short --cov-config .coveragerc --cov=steam tests
+	PYTHONHASHSEED=0 pytest --tb=short $(COVOPTS) tests
 
 webauth_gen:
 	rm -f vcr/webauth*

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     keywords='valve steam steamid api webapi steamcommunity',


### PR DESCRIPTION
* Include python 3.9 and pypy in test matrix
* do not install docs deps when running tests
* no coverage for pypy (coveragepy doesn't support gevent under pypy)