### PR TITLE
Correct TOTP URI

### DIFF
--- a/steam/guard.py
+++ b/steam/guard.py
@@ -183,7 +183,7 @@ class SteamAuthenticator(object):
         try:
             if not re.search(r'[&\?].*digits', resp['uri']):
                 resp['uri'] += '&digits=5'
-        except KeyError, AttributeError:
+        except (KeyError, AttributeError):
             pass
 
         self.secrets = resp

--- a/steam/guard.py
+++ b/steam/guard.py
@@ -181,7 +181,7 @@ class SteamAuthenticator(object):
             raise SteamAuthenticatorError("Failed to add authenticator. Error: %s" % repr(EResult(resp['status'])))
 
         try:
-            if not re.search('[&\?].*digits', resp['uri']):
+            if not re.search(r'[&\?].*digits', resp['uri']):
                 resp['uri'] += '&digits=5'
         except KeyError, AttributeError:
             pass

--- a/steam/guard.py
+++ b/steam/guard.py
@@ -49,6 +49,7 @@ import json
 import subprocess
 import struct
 import requests
+import re
 from base64 import b64decode, b64encode
 from binascii import hexlify
 from time import time
@@ -178,6 +179,12 @@ class SteamAuthenticator(object):
 
         if resp['status'] != EResult.OK:
             raise SteamAuthenticatorError("Failed to add authenticator. Error: %s" % repr(EResult(resp['status'])))
+
+        try:
+            if not re.search('[&\?].*digits', resp['uri']):
+                resp['uri'] += '&digits=5'
+        except KeyError, AttributeError:
+            pass
 
         self.secrets = resp
         self.steam_time_offset = int(resp['server_time']) - time()

--- a/steam/guard.py
+++ b/steam/guard.py
@@ -183,7 +183,7 @@ class SteamAuthenticator(object):
         try:
             if not re.search(r'[&\?].*digits', resp['uri']):
                 resp['uri'] += '&digits=5'
-        except (KeyError, AttributeError):
+        except (KeyError, TypeError):
             pass
 
         self.secrets = resp


### PR DESCRIPTION
Steam requires a 5-digit code, but most TOTP software has 6 digits as the default when a length is not specified.

This commit will patch, when necessary, the value of Steam's endpoint's erroneous response.