### PR TITLE
properly pass `http_timeout`

### DIFF
--- a/steam/steamid.py
+++ b/steam/steamid.py
@@ -597,7 +597,7 @@ def from_url(url, http_timeout=30):
 
     """
 
-    steam64 = steam64_from_url(url)
+    steam64 = steam64_from_url(url, http_timeout)
 
     if steam64:
         return SteamID(steam64)


### PR DESCRIPTION
to me it looks like this was just accidentally left out, as right now this param does nothing.