### PR TITLE
replace `else: if:` with a literal `elif`

### DIFF
--- a/steam/client/__init__.py
+++ b/steam/client/__init__.py
@@ -297,9 +297,8 @@ class SteamClient(CMClient, BuiltinBase):
         """
         if not self.connected:
             self._LOG.debug("Trying to send message when not connected. (discarded)")
-        else:
-            if body_params and isinstance(message, MsgProto):
-                proto_fill_from_dict(message.body, body_params)
+        elif body_params and isinstance(message, MsgProto):
+            proto_fill_from_dict(message.body, body_params)
 
             CMClient.send(self, message)
 

--- a/steam/client/__init__.py
+++ b/steam/client/__init__.py
@@ -297,8 +297,9 @@ class SteamClient(CMClient, BuiltinBase):
         """
         if not self.connected:
             self._LOG.debug("Trying to send message when not connected. (discarded)")
-        elif body_params and isinstance(message, MsgProto):
-            proto_fill_from_dict(message.body, body_params)
+        else:
+            if body_params and isinstance(message, MsgProto):
+                proto_fill_from_dict(message.body, body_params)
 
             CMClient.send(self, message)
 

--- a/steam/webauth.py
+++ b/steam/webauth.py
@@ -179,11 +179,10 @@ class WebAuth(object):
 
         if password:
             self.password = password
+        elif self.password:
+            password = self.password
         else:
-            if self.password:
-                password = self.password
-            else:
-                raise LoginIncorrect("password is not specified")
+            raise LoginIncorrect("password is not specified")
 
         if not captcha and self.captcha_code:
             captcha = self.captcha_code
@@ -339,17 +338,15 @@ class MobileWebAuth(WebAuth):
         """
         if oauth_token:
             self.oauth_token = oauth_token
+        elif self.oauth_token:
+            oauth_token = self.oauth_token
         else:
-            if self.oauth_token:
-                oauth_token = self.oauth_token
-            else:
-                raise LoginIncorrect('token is not specified')
+            raise LoginIncorrect('token is not specified')
 
         if steam_id:
             self.steam_id = SteamID(steam_id)
-        else:
-            if not self.steam_id:
-                raise LoginIncorrect('steam_id is not specified')
+        elif not self.steam_id:
+            raise LoginIncorrect('steam_id is not specified')
 
         steam_id = self.steam_id.as_64
 


### PR DESCRIPTION
In my opinion, `elif`s look better because there is no change in indentation level, but these should function the exact same. I'm not experienced with python 2, but I can't imagine this would make a difference.