### PR TITLE
Remove gevent monkey patch by default in steam.client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change notes
 
+## 2.0.0
+
+This release brings breaking changes
+
+### steam.cleint
+
+- Removed monkey patching by default. See `steam.client.monkey` for details
+
 ## 1.0.0
 
 This release brings breaking changes

--- a/docs/api/steam.client.monkey.rst
+++ b/docs/api/steam.client.monkey.rst
@@ -1,0 +1,7 @@
+monkey
+======
+
+.. automodule:: steam.client.monkey
+    :members:
+    :show-inheritance:
+

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -153,6 +153,10 @@ SteamClient
 ``gevent`` based implementation for interacting with the Steam network.
 The library comes with some Steam client features implemented, see :doc:`api/steam.client` for more details.
 
+.. warning::
+    :class:`.SteamClient` no longer applies gevent monkey patches by default.
+    See :mod:`steam.client.monkey` for details how make stdlib gevent cooperative.
+
 CLI example
 -----------
 

--- a/steam/client/__init__.py
+++ b/steam/client/__init__.py
@@ -1,6 +1,11 @@
 """
 Implementation of Steam client based on ``gevent``
 
+.. warning::
+    ``steam.client`` no longer patches stdlib to make it gevent cooperative.
+    This provides flexibility if you want to use :class:`.SteamClient` with async or other modules.
+    If you want to monkey patch anyway use :meth:`steam.client.monkey.patch_minimal()`
+
 .. note::
     Additional features are located in separate submodules. All functionality from :mod:`.builtins` is inherited by default.
 
@@ -8,11 +13,6 @@ Implementation of Steam client based on ``gevent``
     Optional features are available as :mod:`.mixins`. This allows the client to remain light yet flexible.
 
 """
-import gevent
-import gevent.monkey
-gevent.monkey.patch_socket()
-gevent.monkey.patch_ssl()
-
 import os
 import json
 from random import random

--- a/steam/client/cdn.py
+++ b/steam/client/cdn.py
@@ -3,9 +3,20 @@ The :class:`.CDNClient` class provides a simple API for downloading Steam conten
 
 Initializing :class:`.CDNClient` requires a logged in :class:`.SteamClient` instance
 
+.. warning::
+    This module uses :mod:`requests` library, which is not gevent cooperative by default.
+    It is high recommended that you use :meth:`steam.client.monkey.patch_minimal()`.
+    See example below
+
 .. code:: python
+    import steam.client.monkey
+    steam.client.monkey.patch_minimal()
+
+    from steam.client import SteamClient, EMsg
+    from steam.client.cdn import CDNClient
 
     mysteam = SteamClient()
+    mysteam.cli_login()
     ...
     mycdn = CDNClient(mysteam)
 

--- a/steam/client/monkey.py
+++ b/steam/client/monkey.py
@@ -1,0 +1,27 @@
+"""
+Helper moduel for calling ``gevent`` monkey patch functions.
+This only need to if want to make stdlib gevent cooperative.
+The patches need to be applied before any other module imports.
+
+See :mod:`gevent.monkey` for details
+
+.. code:: python
+
+    import steam.client.monkey
+    steam.client.monkey.patch_minimal()
+
+    import requests
+    from steam.client import SteamClient, EMsg
+"""
+
+def patch_minimal():
+    """
+    This method needs to be called before any other imports
+
+    It calls :meth:`gevent.monkey.patch_socket()` and :meth:`gevent.monkey.patch_ssl()`
+    """
+    import gevent
+    import gevent.monkey
+    gevent.monkey.patch_socket()
+    gevent.monkey.patch_ssl()
+    gevent.monkey.patch_dns()

--- a/steam/client/monkey.py
+++ b/steam/client/monkey.py
@@ -20,7 +20,6 @@ def patch_minimal():
 
     It calls :meth:`gevent.monkey.patch_socket()` and :meth:`gevent.monkey.patch_ssl()`
     """
-    import gevent
     import gevent.monkey
     gevent.monkey.patch_socket()
     gevent.monkey.patch_ssl()


### PR DESCRIPTION
* Removes monkey patching from `steam.client` module
* Add docs explaining the change
* Add new `steam.client.monkey.patch_minimal()` for applying minimal necessary monkey patching 