### PR TITLE
cdn: Cope with depots with no name

### DIFF
--- a/steam/client/cdn.py
+++ b/steam/client/cdn.py
@@ -740,7 +740,7 @@ class CDNClient(object):
                and depot_id not in self.licensed_depot_ids
                and depot_id not in self.licensed_app_ids):
                 self._LOG.debug("No license for depot %s (%s). Skipping...",
-                                repr(depot_info['name']),
+                                repr(depot_info.get('name', depot_id)),
                                 depot_id,
                                 )
                 continue
@@ -769,7 +769,7 @@ class CDNClient(object):
                                               depot_id,
                                               manifest_gid,
                                               decrypt,
-                                              depot_info['name'],
+                                              depot_info.get('name', depot_id),
                                               ))
 
         # collect results


### PR DESCRIPTION
App ID 1628350 "Steam Linux Runtime - Sniper" contains depot 1628351,
which has no name, causing steam.client.cdn.CDNClient to crash with
a KeyError while retrieving manifests from that depot. Fall back to
using the depot ID as a placeholder name.