### PR TITLE
CDNClient: Cope with longer manifest descriptions for some depots

### DIFF
--- a/steam/client/cdn.py
+++ b/steam/client/cdn.py
@@ -836,6 +836,12 @@ class CDNClient(object):
             else:
                 manifest_gid = depot_info.get('manifests', {}).get(branch)
 
+            if isinstance(manifest_gid, dict):
+                # For some depots, Steam has started returning a dict
+                # {"public": {"gid": GID, "size": ..., "download": ...}, ...}
+                # instead of a simple map {"public": GID, ...}
+                manifest_gid = manifest_gid['gid']
+
             if manifest_gid is not None:
                 tasks.append(
                     self.gpool.spawn(


### PR DESCRIPTION
Some depots now have a dict like `{"public": {"gid": GID, ...}, ...}` where we would traditionally have seen a flat dict `{"public": GID, ...}`. Not all depots have this: at the time of writing,
1628350 "Steam Linux Runtime - Sniper" does, but
1391110 "Steam Linux Runtime - Soldier" does not. Presumably this is a change that is being rolled out gradually to let the Steam client give better estimates of the size of a depot.

Cope with either format, by retrieving the gid field if the nested dict is present.

Resolves: https://github.com/ValvePython/steam/issues/436