### PR TITLE
Update CI configuration to a working state

### DIFF
--- a/.github/workflows/testing_initiative.yml
+++ b/.github/workflows/testing_initiative.yml
@@ -46,9 +46,9 @@ jobs:
             python-version: pypy-3.6
             no-coverage: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python Env
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -94,9 +94,9 @@ jobs:
           - ubuntu-20.04
         python-version: [3.6]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python Env
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version

--- a/.github/workflows/testing_initiative.yml
+++ b/.github/workflows/testing_initiative.yml
@@ -32,14 +32,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+         - ubuntu-20.04
+         - macos-latest
+         - windows-latest
         python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
         no-coverage: [0]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: pypy-2.7
             no-coverage: 1
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: pypy-3.6
             no-coverage: 1
     steps:
@@ -71,7 +74,7 @@ jobs:
   coveralls:
     name: Finish Coveralls
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: python:3-slim
     steps:
     - name: Install coveralls
@@ -87,7 +90,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os:
+          - ubuntu-20.04
         python-version: [3.6]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Close #425 as this superseed it. Newer python version cannot be added until support for python <=3.6 is dropped