### PR TITLE
Add support for python 3.10 and 3.11 back

### DIFF
--- a/.github/workflows/testing_initiative.yml
+++ b/.github/workflows/testing_initiative.yml
@@ -36,7 +36,7 @@ jobs:
          - ubuntu-20.04
          - macos-latest
          - windows-latest
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10", 3.11]
         no-coverage: [0]
         include:
           - os: ubuntu-20.04

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,8 @@
 
 -r requirements.txt
 
-vcrpy==2.0.1
+vcrpy==2.0.1; python_version <= '3.6'
+vcrpy==4.3.0; python_version > '3.6'
 PyYAML>=5.4
 mock==1.3.0
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     keywords='valve steam steamid api webapi steamcommunity',


### PR DESCRIPTION
It looks like the only thing that was preventing 3.10 and 3.11 from working was vcrpy version which can be installed in the correct version using conditional dependencies.