### PR TITLE
appcache: add new magic for Steam Client Beta (June 2024)

### DIFF
--- a/steam/utils/appcache.py
+++ b/steam/utils/appcache.py
@@ -7,7 +7,7 @@ Appache file parsing examples:
 
     >>> header, apps = parse_appinfo(open('/d/Steam/appcache/appinfo.vdf', 'rb'))
     >>> header
-    {'magic': b"(DV\\x07", 'universe': 1}
+    {'magic': b")DV\\x07", 'universe': 1}
     >>> next(apps)
     {'appid': 5,
      'size': 79,
@@ -53,7 +53,7 @@ def parse_appinfo(fp):
     :return: (header, apps iterator)
     """
 # format:
-#   uint32   - MAGIC: "'DV\x07" or "(DV\x07"
+#   uint32   - MAGIC: "'DV\x07" or "(DV\x07" or b")DV\x07"
 #   uint32   - UNIVERSE: 1
 #   ---- repeated app sections ----
 #   uint32   - AppID

--- a/steam/utils/appcache.py
+++ b/steam/utils/appcache.py
@@ -69,7 +69,7 @@ def parse_appinfo(fp):
 #   uint32   - EOF: 0
 
     magic = fp.read(4)
-    if magic not in (b"'DV\x07", b"(DV\x07"):
+    if magic not in (b"'DV\x07", b"(DV\x07", b")DV\x07"):
         raise SyntaxError("Invalid magic, got %s" % repr(magic))
 
     universe = uint32.unpack(fp.read(4))[0]


### PR DESCRIPTION
Fix #462.

The latest Steam Client Beta changed the magic for `appinfo.vdf`. This PR adds the new magic to the file. I confirmed that this allows my `appinfo.vdf` to be parsed, but have not checked for backwards compatibility (although it should work given that we check based on a tuple of magics).

Unsure how the `data_sha1` should look, and if the `if` check needs to now include the new magic too. Alternatively the `if` could be changed to `if magic != b"'DV\x07"`, but have not tested this.

I am using this as a reference implementation, although my C# skills are close to zero :sweat_smile: https://github.com/SteamDatabase/SteamAppInfo/commit/56b1fec7f5ce6be961c3e44cf9baf117e363ad91