### PR TITLE
Get the gid from the branch dict when not encrypted.

### DIFF
--- a/steam/client/cdn.py
+++ b/steam/client/cdn.py
@@ -832,9 +832,9 @@ class CDNClient(object):
                     manifest_gid = decrypt_manifest_gid_2(unhexlify(egid),
                                                           self.beta_passwords[(app_id, branch)])
                 else:
-                    manifest_gid = depot_info.get('manifests', {}).get('public')
+                    manifest_gid = depot_info.get('manifests', {}).get('public').get('gid')
             else:
-                manifest_gid = depot_info.get('manifests', {}).get(branch)
+                manifest_gid = depot_info.get('manifests', {}).get(branch).get('gid')
 
             if manifest_gid is not None:
                 tasks.append(


### PR DESCRIPTION
I found the following error when trying to pull the manifest information of a specific appid:
```python
>>> from steam.client.cdn import CDNClient
>>> client = SteamClient()
>>> client.anonymous_login()

<EResult.OK: 1>
>>> mycdn = CDNClient(client)
>>> mycdn.get_manifests(730)
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/Data/Development/python-venv/lib/python3.12/site-packages/steam/client/cdn.py", line 857, in get_manifests
    result = task.get()
             ^^^^^^^^^^
  File "src/gevent/greenlet.py", line 829, in gevent._gevent_cgreenlet.Greenlet.get
  File "src/gevent/greenlet.py", line 373, in gevent._gevent_cgreenlet.Greenlet._raise_exception
  File "/mnt/Data/Development/python-venv/lib/python3.12/site-packages/gevent/_compat.py", line 50, in reraise
    raise value.with_traceback(tb)
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/mnt/Data/Development/python-venv/lib/python3.12/site-packages/steam/client/cdn.py", line 785, in async_fetch_manifest
    app_id, depot_id, int(manifest_gid), branch_name, branch_pass
^^^^^^^
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'dict'
```

It seemed that it was setting the whole depot branch dict as manifest_gid instead of the gid only for non-encrypted branches. Therefor I made this small bugfix to set the gid from the branch instead. See here the results:

```python
>>> from steam.client import SteamClient
>>> from steam.client.cdn import CDNClient
>>>
>>> client = SteamClient()
>>> client.anonymous_login()
<EResult.OK: 1>
>>> mycdn = CDNClient(client)
>>> mycdn.get_manifests(730)
[<CDNDepotManifest(731, app_id=730, depot_id=731, gid=7233957520227140199, creation_time='2024-10-25 18:03:57')>, <CDNDepotManifest(2347770, app_id=730, depot_id=2347770, gid=6010599137649566576, creation_time='2024-10-25 18:05:47')>, <CDNDepotManifest(2347771, app_id=730, depot_id=2347771, gid=55193810267189550, creation_time='2024-10-25 18:06:17')>, <CDNDepotManifest(2347773, app_id=730, depot_id=2347773, gid=4272288505887646214, creation_time='2024-10-25 18:06:23')>, <CDNDepotManifest(2347774, app_id=730, depot_id=2347774, gid=2942185934659498548, creation_time='2024-10-01 23:54:10')>, <CDNDepotManifest(228988, app_id=228980, depot_id=228988, gid=6645201662696499616, creation_time='2022-05-04 21:41:13')>, <CDNDepotManifest(228990, app_id=228980, depot_id=228990, gid=1829726630299308803, creation_time='2013-02-18 21:47:57')>]
```